### PR TITLE
Fix input field resolution in case validation changes input value

### DIFF
--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -101,7 +101,6 @@ def validated(cls):
             # Run field level validation logic
             for ftv in fields_to_validate:
                 name, value, validator, _parent, _idx = ftv
-                path = _get_path(ftv)
                 try:
                     new_value = getattr(
                         validator,
@@ -110,12 +109,14 @@ def validated(cls):
                     )(value, info, **kwargs)
                     # If validator changed the value we need to update it in the input tree
                     if new_value != value:
+                        path = _get_path(ftv, False)
                         # Grab a ref to the field to change by following the path in the input tree
                         field = functools.reduce(
                             lambda obj, k: obj[k] if k else obj, path[:-1], input_tree
                         )
                         field[name] = new_value
                 except ValidationError as ve:
+                    path = _get_path(ftv)
                     errors.append({"code": str(ve), "path": path, "meta": ve.meta})
 
             # Don't run subtree level validation if one or more fields are invalid

--- a/graphene_validator/utils.py
+++ b/graphene_validator/utils.py
@@ -7,15 +7,16 @@ def _to_camel_case(name):
     )
 
 
-def _get_path(field):
+def _get_path(field, camel_case=True):
     """
     Reconstruct the path to the given field, including list indices.
     """
+    name_transform = _to_camel_case if camel_case else lambda text: text
     name, _value, _validator, parent, idx = field
-    path = [idx, _to_camel_case(name)] if idx is not None else [_to_camel_case(name)]
+    path = [idx, name_transform(name)] if idx is not None else [name_transform(name)]
     while parent:
         pname, _pvalue, _pvalidator, parent, pidx = parent
-        path.insert(0, _to_camel_case(pname))
+        path.insert(0, name_transform(pname))
         if pidx:
             path.insert(0, pidx)
     return path

--- a/tests.py
+++ b/tests.py
@@ -77,15 +77,19 @@ class TestInput(graphene.InputObjectType):
         return inpt
 
 
+class TestMutationOutput(graphene.ObjectType):
+    email = graphene.String()
+
+
 @validated
 class TestMutation(graphene.Mutation):
     class Arguments:
         _inpt = graphene.Argument(TestInput, name="input")
 
-    result = graphene.String()
+    Output = TestMutationOutput
 
     def mutate(self, _info, _inpt):
-        return TestMutation(result=_inpt.get("email"))
+        return TestMutationOutput(email=_inpt.get("email"))
 
 
 class Mutations(graphene.ObjectType):
@@ -101,7 +105,7 @@ class TestValidation:
         request_string="""
         mutation Test($input: TestInput!) {
             testMutation(input: $input) {
-                result
+                email
             }
         }"""
     )
@@ -142,7 +146,7 @@ class TestValidation:
         )
         result = schema.execute(**request)
         assert not result.errors
-        assert result.data["testMutation"]["result"] == "a0@b.c"
+        assert result.data["testMutation"]["email"] == "a0@b.c"
 
     def test_transform(self):
         request = dict(
@@ -156,7 +160,7 @@ class TestValidation:
         )
         result = schema.execute(**request)
         assert not result.errors
-        assert result.data["testMutation"]["result"] == "a0@b.c"
+        assert result.data["testMutation"]["email"] == "a0@b.c"
 
     def test_root_validate(self):
         request = dict(

--- a/tests.py
+++ b/tests.py
@@ -30,7 +30,7 @@ class PersonalDataInput(graphene.InputObjectType):
     def validate_the_name(name):
         if len(name) == 0:
             raise EmptyString
-        return name
+        return name.strip()
 
     @staticmethod
     def validate_the_age(age):
@@ -49,7 +49,8 @@ class TestInput(graphene.InputObjectType):
     email = graphene.String()
     people = graphene.List(PersonalDataInput)
     numbers = graphene.List(graphene.Int)
-    person = graphene.InputField(PersonalDataInput)
+    # Check camelCasing too
+    the_person = graphene.InputField(PersonalDataInput)
 
     @staticmethod
     def validate_email(email):
@@ -77,8 +78,13 @@ class TestInput(graphene.InputObjectType):
         return inpt
 
 
+class PersonalData(graphene.ObjectType):
+    the_name = graphene.String()
+
+
 class TestMutationOutput(graphene.ObjectType):
     email = graphene.String()
+    the_person = graphene.Field(PersonalData)
 
 
 @validated
@@ -89,7 +95,10 @@ class TestMutation(graphene.Mutation):
     Output = TestMutationOutput
 
     def mutate(self, _info, _inpt):
-        return TestMutationOutput(email=_inpt.get("email"))
+        return TestMutationOutput(
+            email=_inpt.get("email"),
+            the_person=_inpt.get("the_person"),
+        )
 
 
 class Mutations(graphene.ObjectType):
@@ -106,6 +115,9 @@ class TestValidation:
         mutation Test($input: TestInput!) {
             testMutation(input: $input) {
                 email
+                thePerson {
+                    theName
+                }
             }
         }"""
     )
@@ -154,13 +166,14 @@ class TestValidation:
             variable_values={
                 "input": {
                     "email": " a0@b.c ",
-                    "people": [{"theName": "a", "theAge": "0"}],
+                    "thePerson": {"theName": " a ", "theAge": "0"},
                 }
             },
         )
         result = schema.execute(**request)
         assert not result.errors
         assert result.data["testMutation"]["email"] == "a0@b.c"
+        assert result.data["testMutation"]["thePerson"]["theName"] == "a"
 
     def test_root_validate(self):
         request = dict(
@@ -199,7 +212,7 @@ class TestValidation:
         validation_errors = result.errors[0].extensions["validationErrors"]
         assert validation_errors[0]["path"] == ["name"]
         request["variable_values"] = {
-            "input": {"person": {"theName": "0", "theAge": 0}}
+            "input": {"thePerson": {"theName": "0", "theAge": 0}}
         }
         result = schema.execute(**request)
         validation_errors = result.errors[0].extensions["validationErrors"]


### PR DESCRIPTION
Previously `camelCase` names were used to find the field from the input tree. But the input tree uses `snake_case` key names, so that didn't work. Changed tests to cover this case.